### PR TITLE
feat: create releases with each merge to main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,63 @@
+name: Github Release
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main"]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Enable yarn berry
+        run: corepack enable
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v4
+        with:
+          # Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm.
+          cache: yarn
+          # Used to specify the path to a dependency file: package-lock.json, yarn.lock, etc. Supports wildcards or a list of file names for caching multiple dependencies.
+          cache-dependency-path: yarn.lock
+          # Version Spec of the version to use. Examples: 12.x, 10.15.1, >=10.15.0.
+          node-version: 22.x
+      - name: Install dependencies
+        run: yarn
+      - name: Run build
+        run: yarn build
+      - name: Upload data for release job
+        uses: actions/upload-artifact@v4
+        with:
+          name: release_contents
+          path: |
+            dist
+
+  # Create GitHub Release
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download artifacts from build
+        uses: actions/download-artifact@v4
+        with:
+          name: release_contents
+          path: dist
+      - name: Creates a release in GitHub and uploads attachments
+        run: |
+          ls -la
+          RELEASE_VERSION="$(npm pkg get version | tr -d '"')"
+          RELEASE_FILENAME="v${RELEASE_VERSION}.zip"
+          cd dist
+          zip -r "${RELEASE_FILENAME}" ./*
+          gh release create "v${RELEASE_VERSION}" "${RELEASE_FILENAME}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash


### PR DESCRIPTION
This will allow simpler deployment to other hosting platforms by creating a zipped archive to download and then upload to the platform of choice.