### PR TITLE
🐛 fix: manually force the Git tags to be fetched

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Fetch tags manually
+        run: git fetch --force --tags
+
       - name: Download artifacts
         uses: actions/download-artifact@v7
         with:


### PR DESCRIPTION
Fix the release by forcing git to fetch the tags